### PR TITLE
Fix- Cancel api request 

### DIFF
--- a/app/src/main/java/com/example/wikipediasearch/ui/searchQueryResult/SearchQueryResultContract.kt
+++ b/app/src/main/java/com/example/wikipediasearch/ui/searchQueryResult/SearchQueryResultContract.kt
@@ -13,5 +13,7 @@ interface SearchQueryResultContract {
         fun getSearchQueryResult(query: String)
 
         fun getSearchQueryFromDb(query: String)
+
+        fun cancelQuery()
     }
 }

--- a/app/src/main/java/com/example/wikipediasearch/ui/searchQueryResult/SearchQueryResultFragment.kt
+++ b/app/src/main/java/com/example/wikipediasearch/ui/searchQueryResult/SearchQueryResultFragment.kt
@@ -116,6 +116,7 @@ class SearchQueryResultFragment : BaseFragment(), SearchQueryResultContract.View
                 if(!newText.isNullOrEmpty()){
                     triggerSearch(newText)
                 } else {
+                    searchQueryResultPresenter.cancelQuery()
                     listOfQueryResult.clear()
                     searchQueryResultListAdapter.updateSearchQueryResultList(listOfQueryResult)
                 }

--- a/app/src/main/java/com/example/wikipediasearch/ui/searchQueryResult/SearchQueryResultPresenter.kt
+++ b/app/src/main/java/com/example/wikipediasearch/ui/searchQueryResult/SearchQueryResultPresenter.kt
@@ -1,6 +1,5 @@
 package com.example.wikipediasearch.ui.searchqueryresult
 
-import androidx.lifecycle.LiveData
 import com.example.wikipediasearch.ServiceLocator
 import com.example.wikipediasearch.data.model.WikiMediaResponse
 import io.reactivex.android.schedulers.AndroidSchedulers
@@ -8,7 +7,13 @@ import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.rxkotlin.addTo
 import io.reactivex.schedulers.Schedulers
 
-class SearchQueryResultPresenter(private val serviceLocator: ServiceLocator): SearchQueryResultContract.Presenter{
+class SearchQueryResultPresenter(private val serviceLocator: ServiceLocator) :
+    SearchQueryResultContract.Presenter {
+
+    override fun cancelQuery() {
+        compositeDisposable.clear()
+        view?.hideLoading()
+    }
 
     override var view: SearchQueryResultContract.View? = null
 
@@ -21,9 +26,10 @@ class SearchQueryResultPresenter(private val serviceLocator: ServiceLocator): Se
         serviceLocator.getWikiWebServiceProvider().getResultForSearchQuery(query)
             .subscribeOn(Schedulers.io())
             .observeOn(AndroidSchedulers.mainThread())
-            .subscribe ({success ->
+            .subscribe({ success ->
                 userQuery = query
-                handleSuccess(success)  }, {error ->  })
+                handleSuccess(success)
+            }, { error -> })
             .addTo(compositeDisposable)
     }
 
@@ -35,7 +41,8 @@ class SearchQueryResultPresenter(private val serviceLocator: ServiceLocator): Se
     }
 
     override fun getSearchQueryFromDb(query: String) {
-        val liveDataWikiResponse = serviceLocator.getWikiDbServiceProvider().getSearchQueryResult(query)
+        val liveDataWikiResponse =
+            serviceLocator.getWikiDbServiceProvider().getSearchQueryResult(query)
         liveDataWikiResponse.observeForever {
             view?.updateSearchQueryResult(it?.query?.pages)
         }


### PR DESCRIPTION
Scenario(Bug): When user clear the text from the search. User is still shown the data of previously submitted/last query. 

Fix -when there is no text in the search bar the back-end request is canceled.